### PR TITLE
Depend on environment task in Rake so we get Rails autoload magic

### DIFF
--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -1,6 +1,4 @@
-require "#{Rails.root}/app/services/file_importer.rb"
-
-task :import_ward_data do
+task :import_ward_data => :environment do
   file_importer = FileImporter.new
   csv_file = file_importer.import_file('GIS/Hackathon/', '2012Wards.csv')
 


### PR DESCRIPTION
Instead of requiring the file through straight Ruby, the Rake task can be altered to depend on the `environment` task that autoloads classes like the Rails app normally would.
