### PR TITLE
Add docker-compose support for local development work

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ Another great rails resource: https://www.railstutorial.org/
 
 ### Setting Environment Variables
 The project uses the [dotenv](https://github.com/bkeepers/dotenv) gem to manage environment variables. This is how sensative information is stored (and not committed to source control). To get the application to run, you'll need a file called `.env` in the root of your project. It should have the following items in it:
+
 - FTP_HOST
 - FTP_PORT
 - FTP_USERNAME
 - FTP_PASSWORD
+- POSTGRES_DATABASE
+- POSTGRES_PASSWORD
+- POSTGRES_USERNAME
 
 ### Running the API Server
 1. After downloading the project locally, run `bundle install` in the project root directory.

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,17 +3,19 @@ default: &default
   encoding: unicode
   pool: 5
   host: localhost
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
+  username: <%= ENV['POSTGRES_USERNAME'] %>
 
 development:
   <<: *default
-  database: open-data-api_development
+  database: <%= ENV['POSTGRES_DATABASE'] %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: open-data-api_test
+  database: <%= ENV['POSTGRES_DATABASE'] %>_test
 
 production:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres:9.6-alpine
+    environment:
+      POSTGRES_DB: opendata
+      POSTGRES_PASSWORD: akron
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/env.example
+++ b/env.example
@@ -3,3 +3,6 @@ FTP_PATH="/path/todata"
 FTP_USERNAME="someuserg"
 FTP_PORT="22"
 FTP_PASSWORD="password"
+POSTGRES_DATABASE=opendata
+POSTGRES_PASSWORD=akron
+POSTGRES_USERNAME=postgres


### PR DESCRIPTION
Adds basic support for running Postgres from a `docker-compose` setup.

This PR assumes that it's ok to change the database name of the project and to pull it in from the `.env` file instead of hard-coding it. I'm fine changing anything that needs to be altered to play nice in the project if people are interested in local Docker dev support for the project.

This does not attempt to run a container for the Rails app. That leads to scary things.