### PR TITLE
Add acronym for COA and FTP for correct filename resolution

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'COA'
+  inflect.acronym 'FTP'
+end


### PR DESCRIPTION
I added `COA` and `FTP` to the acronym list so that the file `coa_ftp_connection.rb` can be found by Rails properly.

I also added a `db/seed/` folder to the project by adding a `.gitkeep` file to it so that rake tasks for generating seed data will work for people who pull the project fresh from git.