### PR TITLE
Allow response to basic parcel api endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,14 @@ ruby "2.3.1"
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'dotenv-rails'
 gem 'jbuilder', '~> 2.5'
+gem 'kaminari'
 gem 'pg', '~> 0.18.4'
 gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem "paper_trail"
 gem "dotenv"
 gem 'resque', "~> 1.22.0"
+
 group :development, :test do
   gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,18 @@ GEM
     json (1.8.3)
     jsonapi (0.1.1.beta2)
       json (~> 1.8)
+    kaminari (1.0.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.0.1)
+      kaminari-activerecord (= 1.0.1)
+      kaminari-core (= 1.0.1)
+    kaminari-actionview (1.0.1)
+      actionview
+      kaminari-core (= 1.0.1)
+    kaminari-activerecord (1.0.1)
+      activerecord
+      kaminari-core (= 1.0.1)
+    kaminari-core (1.0.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -165,6 +177,7 @@ DEPENDENCIES
   dotenv
   dotenv-rails
   jbuilder (~> 2.5)
+  kaminari
   listen (~> 3.0.5)
   paper_trail
   pg (~> 0.18.4)
@@ -181,4 +194,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/app/controllers/api/parcels_controller.rb
+++ b/app/controllers/api/parcels_controller.rb
@@ -1,9 +1,9 @@
 class API::ParcelsController < API::BaseController
   def index
-    render json: { hello: 'world' }
+    render json: Parcel.order(:id).page(params[:page]).per(params[:per_page])
   end
 
   def show
-    render json: { hello: 'show' }
+    render json: Parcel.find_by(parcel_id: params[:id])
   end
 end

--- a/app/controllers/api/root_controller.rb
+++ b/app/controllers/api/root_controller.rb
@@ -1,6 +1,6 @@
 class API::RootController < API::BaseController
   def index
-    @response = {
+    api_information = {
       data: {
         organization: 'Hack N Akron',
         project: {
@@ -19,6 +19,6 @@ class API::RootController < API::BaseController
       errors: {}
     }
 
-    render json: @response
+    render json: api_information
   end
 end

--- a/app/models/parcel.rb
+++ b/app/models/parcel.rb
@@ -1,4 +1,7 @@
 class Parcel < ApplicationRecord
+  paginates_per 50
+  max_paginates_per 100
+
   validates :object_id, presence: true
   validates :parcel_id, presence: true
 
@@ -6,5 +9,4 @@ class Parcel < ApplicationRecord
 
   has_many :parcel_sales
   has_many :parcel_appraisals
-
 end


### PR DESCRIPTION
This adds basic support for the parcel apis where the user can specify `page` and a `per_page` query parameters to limit the responses. The user is unable to pull more than 100 objects per request though.