### PR TITLE
Add explicit filtering params for Parcels API

### DIFF
--- a/app/controllers/api/parcels_controller.rb
+++ b/app/controllers/api/parcels_controller.rb
@@ -1,9 +1,20 @@
 class API::ParcelsController < API::BaseController
   def index
-    render json: Parcel.order(:id).page(params[:page]).per(params[:per_page])
+    render json: Parcel.order(:id).where(filter_params).page(params[:page]).per(params[:per_page])
   end
 
   def show
     render json: Parcel.find_by(parcel_id: params[:id])
   end
+
+  private
+
+    def filter_params
+      params.fetch('filters', {}).permit(
+        'object_id' => [],
+        'tax_year' => [],
+        'use_class' => [],
+        'use_code' => [],
+      )
+    end
 end


### PR DESCRIPTION
This utilizes a native filtering logic that is explicit in the controllers. May move logic to a concern in the future to clean up user input before passing it in a `where` statement to the database.